### PR TITLE
Fix code coverage

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,3 @@
-require 'coveralls'
-Coveralls.wear!
-
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "ast_transform"
 

--- a/test/test_loader.rb
+++ b/test/test_loader.rb
@@ -10,7 +10,6 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
 )
 SimpleCov.start do
   add_filter('/test/')
-  add_filter('/tmp/')
 end
 
 $LOAD_PATH.unshift(File.expand_path("../../lib", __FILE__))

--- a/test/test_loader.rb
+++ b/test/test_loader.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+require 'simplecov'
+require 'coveralls'
+
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+  [
+    SimpleCov::Formatter::HTMLFormatter,
+    Coveralls::SimpleCov::Formatter
+  ]
+)
+SimpleCov.start do
+  add_filter('/test/')
+  add_filter('/tmp/')
+end
+
+$LOAD_PATH.unshift(File.expand_path("../../lib", __FILE__))
 require "ast_transform"
 
 # Pry


### PR DESCRIPTION
### What
* Improvements to #2
* I had initially intended so that ASTTransform could re-use RSpock as a development dependency, but never actually leveraged that. There were some quirks (that I don't have context on anymore) around installing the hook, so I ended up creating a `test_loader.rb` file that is loaded from the Rakefile's `test` task. This calls `require 'ast_transform'` already, so in `test_helper.rb` the application code has already been required, which breaks SimpleCov, since `SimpleCov.start` must be run before any application code is loaded.

### How
* Moving this to `test_loader.rb` fixes coverage report.
* I also took the liberty of ignoring the `test` directory, as we shouldn't report on test files.

### Other
Interestingly, this revealed a bug with the ASTTransform hook picking up the `transform!` annotation from `transformation_test.rb` and running the transformation on that file: #4 