### PR TITLE
Add Ruby 4.0 support via Prism parser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2', '3.3']
+        ruby: ['3.2', '3.3', '4.0']
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    ast_transform (2.0.0)
+    ast_transform (2.1.0)
       parser (>= 3.0)
+      prism (>= 1.5)
       unparser (>= 0.6)
 
 GEM

--- a/ast_transform.gemspec
+++ b/ast_transform.gemspec
@@ -31,5 +31,6 @@ Gem::Specification.new do |spec|
 
   # Runtime dependencies
   spec.add_runtime_dependency "parser", ">= 3.0"
+  spec.add_runtime_dependency "prism", ">= 1.5"
   spec.add_runtime_dependency "unparser", ">= 0.6"
 end

--- a/lib/ast_transform/source_map.rb
+++ b/lib/ast_transform/source_map.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'parser/current'
+require 'parser'
 
 module ASTTransform
   class SourceMap

--- a/lib/ast_transform/transformer.rb
+++ b/lib/ast_transform/transformer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require 'parser/current'
+require 'prism'
+require 'prism/translation/parser'
 require 'unparser'
 require 'ast_transform/source_map'
 
@@ -8,8 +9,8 @@ module ASTTransform
     # Constructs a new Transformer instance.
     #
     # @param transformations [Array<ASTTransform::AbstractTransformation>] The transformations to be run.
-    # @param builder [Parser::Builders::Default] The AST Node builder.
-    def initialize(*transformations, builder: Parser::Builders::Default.new)
+    # @param builder [Prism::Translation::Parser::Builder] The AST Node builder.
+    def initialize(*transformations, builder: Prism::Translation::Parser::Builder.new)
       @transformations = transformations
       @builder = builder
     end
@@ -99,7 +100,7 @@ module ASTTransform
 
     def parser
       @parser&.reset
-      @parser ||= Parser::CurrentRuby.new(@builder)
+      @parser ||= Prism::Translation::Parser.new(@builder)
     end
 
     def register_source_map(source_file_path, transformed_file_path, transformed_ast, transformed_source)

--- a/lib/ast_transform/version.rb
+++ b/lib/ast_transform/version.rb
@@ -1,3 +1,3 @@
 module ASTTransform
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
## Summary

- Switch from `Parser::CurrentRuby` to `Prism::Translation::Parser` for future-proof Ruby 4.0+ syntax support
- On Ruby 4.0, `Parser::CurrentRuby` silently falls back to `Parser::Ruby33` since the `parser` gem doesn't know about Ruby 4.0 yet. This works for now but won't handle Ruby 4.0-specific syntax.
- `Prism::Translation::Parser` is a drop-in replacement (extends `Parser::Base`, same interface) and uses Ruby's built-in Prism parser
- Use `Prism::Translation::Parser::Builder` as default builder (avoids deprecation warning)
- Add explicit `prism` runtime dependency (was already a transitive dependency via `unparser`)
- Add Ruby 4.0 to CI matrix (3.2, 3.3, 4.0)
- Bump version to 2.1.0

## Test plan

- [x] All 30 tests pass on Ruby 3.3
- [x] All 30 tests pass on Ruby 4.0
- [x] CI passes on Ruby 3.2, 3.3, 4.0

Made with [Cursor](https://cursor.com)